### PR TITLE
Eval v1

### DIFF
--- a/src/edt_trainer.py
+++ b/src/edt_trainer.py
@@ -114,6 +114,7 @@ class EDTTrainer:
         state_size: int,
         action_size: int,
         state_test: torch.Tensor,
+        state_test_denorm: torch.Tensor,
         rtg_target: int = 1,
         # heuristic: bool = False,
         top_percentile: float = 0.15,
@@ -129,11 +130,12 @@ class EDTTrainer:
         test the model
 
         state_test.shape -> shape(290, 4) at year 2011
+        state_test_denorm.shape -> shape(290, 4) at year 2011
         state_size: (int) -> 4
         action_size: (int) -> 4
         trg: (int) -> 1
         """
-        env = TradeEnv(state_test)
+        env = TradeEnv(state_test, state_test_denorm)
         eval_batch_size = 1
         num_eval_ep = 1
         total_reward = 0

--- a/src/edt_trainer.py
+++ b/src/edt_trainer.py
@@ -227,7 +227,6 @@ class EDTTrainer:
                         [running_state[1:], last_state],
                         dim=0
                     )
-                    print(action_pred)
                     actions[0, t] = action_pred
                     total_reward += running_reward
                     edt_weights.append(action_pred.tolist())

--- a/src/model/edt_model.py
+++ b/src/model/edt_model.py
@@ -65,8 +65,8 @@ class ElasticDecisionTransformer(DecisionTransformer):
         self.predict_action = nn.Sequential(
             *(
                 [nn.Linear(self.hidden_size, self.action_size)]
-                + ([nn.Tanh()] if self.is_continuous else [])
-                # + ([nn.Sigmoid()] if self.is_continuous else [])
+                # + ([nn.Tanh()] if self.is_continuous else [])
+                + ([nn.Sigmoid()] if self.is_continuous else [])
             )
         )
         self.predict_reward = nn.Linear(self.hidden_size, 1)

--- a/src/model/edt_model.py
+++ b/src/model/edt_model.py
@@ -65,8 +65,8 @@ class ElasticDecisionTransformer(DecisionTransformer):
         self.predict_action = nn.Sequential(
             *(
                 [nn.Linear(self.hidden_size, self.action_size)]
-                # + ([nn.Tanh()] if self.is_continuous else [])
-                + ([nn.Sigmoid()] if self.is_continuous else [])
+                + ([nn.Tanh()] if self.is_continuous else [])
+                # + ([nn.Sigmoid()] if self.is_continuous else [])
             )
         )
         self.predict_reward = nn.Linear(self.hidden_size, 1)

--- a/src/utils/return_search.py
+++ b/src/utils/return_search.py
@@ -6,6 +6,7 @@ import math
 
 import numpy as np
 import torch
+from torch import nn
 from torch.distributions.categorical import Categorical
 
 from ..model.edt_model import ElasticDecisionTransformer
@@ -105,7 +106,7 @@ def return_search(
                 rewards_to_go[:, i : context_len + i],
                 timesteps[:, i : context_len + i],
             )
-
+            act_preds = nn.Sigmoid()(act_preds)
             # first sample return with optimal weight
             # this sampling is the same as mgdt
             if mgdt_sampling:
@@ -151,7 +152,7 @@ def return_search(
                 rewards_to_go[:, t - context_len + 1 + i : t + 1 + i],
                 timesteps[:, t - context_len + 1 + i : t + 1 + i],
             )
-
+            act_preds = nn.Sigmoid()(act_preds)
             # first sample return with optimal weight
             if mgdt_sampling:
                 opt_rtg = expert_sampling(


### PR DESCRIPTION
Fix the issue of returning "None" from `action_pred` in testing part from year 2013

Key change:

- Use origin OHLC data to calculate portfolio return instead of normalized OHLC data